### PR TITLE
add project name to docker-compose

### DIFF
--- a/compose.sh
+++ b/compose.sh
@@ -28,4 +28,5 @@ cd "$( dirname "${BASH_SOURCE[0]}")"
 
 # Execute test runner, logging command used
 set -x
-exec docker-compose --file compose/base.yml --file compose/${config}.yml $args
+exec docker-compose --project-name gauth \
+  --file compose/base.yml --file compose/${config}.yml $args

--- a/compose/base.yml
+++ b/compose/base.yml
@@ -8,8 +8,8 @@ services:
     env_file:
       - base.env
     volumes:
-      - gauth-webapp-postgres-data-local:/var/lib/postgresql/data
-      - gauth-webapp-postgres-backup-local:/backups
+      - webapp-postgres-data-local:/var/lib/postgresql/data
+      - webapp-postgres-backup-local:/backups
 
   # Debug SMTP provider
   mailhog:
@@ -19,5 +19,5 @@ services:
 
 volumes:
   # Persistent volumes for postgres database data
-  gauth-webapp-postgres-data-local:
-  gauth-webapp-postgres-backup-local:
+  webapp-postgres-data-local:
+  webapp-postgres-backup-local:


### PR DESCRIPTION
docker-compose uses the project name as a prefix for all Docker resources it creates. This defaults to the name of the directory holding the compose file. This is not great in our use case because all our compose files live inside a directory named "compose". Specify the docker-compose project name explicitly in the ./compose.sh wrapper.